### PR TITLE
Type hinting

### DIFF
--- a/sdk/action-schema.js
+++ b/sdk/action-schema.js
@@ -405,7 +405,7 @@ class ActionSchema extends Schema {
    * @returns {Object}
    */
   getFiles() {
-    return this._files;
+    return Object.keys(this._files);
   }
 
   /**

--- a/sdk/action-schema.js
+++ b/sdk/action-schema.js
@@ -134,7 +134,7 @@ class ActionSchema extends Schema {
 
   /**
    *
-   * @returns {string|*}
+   * @returns {string}
    */
   getName() {
     return this._name;
@@ -189,7 +189,7 @@ class ActionSchema extends Schema {
 
   /**
    *
-   * @returns true
+   * @returns {boolean}
    */
   hasEntity() {
     return this._entity.hasDefinition();
@@ -366,7 +366,7 @@ class ActionSchema extends Schema {
 
   /**
    *
-   * @returns {Object}
+   * @returns {string[]}
    */
   getParams() {
     return this._params.map((param) =>
@@ -402,7 +402,7 @@ class ActionSchema extends Schema {
 
   /**
    *
-   * @returns {Object}
+   * @returns {string[]}
    */
   getFiles() {
     return Object.keys(this._files);
@@ -420,7 +420,7 @@ class ActionSchema extends Schema {
   /**
    *
    * @param {string} name
-   * @returns {*}
+   * @returns {FileSchema}
    */
   getFileSchema(name) {
     if (!this.hasFile(name)) {

--- a/sdk/action.js
+++ b/sdk/action.js
@@ -168,7 +168,7 @@ class Action extends Api {
 
   /**
    *
-   * @return {Array}
+   * @return {File[]}
    */
   getFiles() {
     return this._transport.getFiles().map((d) => this.getFile(d[m.name]));
@@ -399,7 +399,7 @@ for action: "${this._actionName}"`
    *
    * @param {string} link Link name
    * @param {string} uri Link URI
-   * @return {boolean}
+   * @return {Action}
    */
   setLink(link, uri) {
     if (_.isNil(link)) {
@@ -415,6 +415,7 @@ for action: "${this._actionName}"`
     }
 
     this._transport._setLink(this.getName(), link, uri);
+
     return this;
   }
 

--- a/sdk/api.js
+++ b/sdk/api.js
@@ -133,7 +133,7 @@ class Api {
    * Get variable value
    *
    * @param {string} name Name of the variable
-   * @return {string|null}
+   * @return {string}
    */
   getVariable(name) {
     return this._variables[name] || null;

--- a/sdk/component.js
+++ b/sdk/component.js
@@ -45,6 +45,7 @@ class Component {
   /**
    *
    * @param {Error} error
+   * @private
    */
   _handleUncaughtException(error) {
     logger.error('Uncaught exception', error.toString(), error.stack);
@@ -56,6 +57,7 @@ class Component {
    * @param {string} message
    * @param {number} code
    * @param {string} status
+   * @protected
    */
   _replyWithError(message, code, status) {
     logger.debug('Replying with error');
@@ -71,11 +73,19 @@ class Component {
     this._replyWith('\x00', errorPayload);
   }
 
+  /**
+   *
+   * @private
+   */
   _readCLIOptions() {
     this.cli           = cli.parse();
     this.logger.setLevel(this.cli.debug ? logger.levels.DEBUG : logger.levels.INFO);
   }
 
+  /**
+   *
+   * @private
+   */
   _runStartup() {
     if (!this._startup) {
       return;
@@ -88,6 +98,10 @@ class Component {
     }
   }
 
+  /**
+   *
+   * @private
+   */
   _runShutdown() {
     if (!this._shutdown) {
       return;
@@ -100,6 +114,11 @@ class Component {
     }
   }
 
+  /**
+   *
+   * @param error
+   * @protected
+   */
   _runError(error) {
     if (!this._error) {
       return;
@@ -112,6 +131,10 @@ class Component {
     }
   }
 
+  /**
+   *
+   * @private
+   */
   _softExit() {
     if (this.busy) {
       logger.warning('Component busy. Waiting before shutdown');
@@ -122,6 +145,11 @@ class Component {
 
     this._hardExit();
   }
+
+  /**
+   *
+   * @private
+   */
   _hardExit() {
     logger.debug('Hard exit. Busy: ' + this.busy);
     this._runShutdown();
@@ -129,6 +157,10 @@ class Component {
     this.process.exit(0);
   }
 
+  /**
+   *
+   * @private
+   */
   _closeSocket() {
     try {
       this.socket && this.socket.close();
@@ -137,6 +169,12 @@ class Component {
     }
   }
 
+  /**
+   *
+   * @param metadata
+   * @param payload
+   * @protected
+   */
   _replyWith(metadata, payload) {
     this.busy = true;
     // To check out the output payload, it's better to use katana service/middleware start --transport
@@ -146,6 +184,13 @@ class Component {
     this.busy = false;
   }
 
+  /**
+   *
+   * @param rawActionName
+   * @param encodedMapping
+   * @param encodedPayload
+   * @private
+   */
   _processMessage(rawActionName, encodedMapping, encodedPayload) {
     const actionName = rawActionName.toString();
     const payload    = msgpack.unpack(encodedPayload);
@@ -169,6 +214,11 @@ class Component {
   //   throw new Error('Must be implemented in child class');
   // }
 
+  /**
+   *
+   * @param newMapping
+   * @private
+   */
   _saveNewMapping(newMapping) {
     let list = [];
     Object.keys(newMapping).forEach((serviceName) => {
@@ -187,6 +237,13 @@ class Component {
     this.servicesMapping = list;
   }
 
+  /**
+   *
+   * @param actionName
+   * @param payload
+   * @return {Action}
+   * @private
+   */
   _getAction(actionName, payload) {
     if (!payload) {
       throw new Error('Cannot create action without data');
@@ -213,6 +270,12 @@ class Component {
     );
   }
 
+  /**
+   *
+   * @param payload
+   * @return {Request}
+   * @protected
+   */
   _getRequest(payload) {
     if (!payload) {
       throw new Error('Cannot create Request without data');
@@ -234,6 +297,12 @@ class Component {
     );
   }
 
+  /**
+   *
+   * @param payload
+   * @return {Response}
+   * @protected
+   */
   _getResponse(payload) {
     if (!payload) {
       throw new Error('Cannot create Response without data');
@@ -256,6 +325,12 @@ class Component {
     );
   }
 
+  /**
+   *
+   * @param source
+   * @return {{}}
+   * @private
+   */
   _getParamsAsMap(source = []) {
     let params = {};
 
@@ -267,7 +342,13 @@ class Component {
     return params;
   }
 
-  // https://github.com/kusanagi/katana-sdk-spec#34-string-representation
+  /**
+   *
+   * @see https://github.com/kusanagi/katana-sdk-spec#34-string-representation
+   * @param value
+   * @return {*}
+   * @private
+   */
   _getAsString(value) {
     if (value === null) {
       return 'NULL';
@@ -292,22 +373,42 @@ class Component {
     return 'Unknown value type';
   }
 
+  /**
+   *
+   * @param name
+   * @param callable
+   * @private
+   */
   _setCallback(name, callable) {
     this.callbacks[name] = callable;
   }
 
+  /**
+   *
+   * @param callable
+   * @private
+   */
   _assertValidCallableType(callable) {
     if (typeof callable !== 'function') {
       throw new Error('Argument `callable` must be of type \'function\'');
     }
   }
 
+  /**
+   *
+   * @param callable
+   * @private
+   */
   _assertCallableProvided(callable) {
     if (callable === undefined) {
       throw new Error('Argument `callable` is required');
     }
   }
 
+  /**
+   *
+   * @private
+   */
   _initZMQCommunication() {
     this.socket = zeromq.socket('rep');
 

--- a/sdk/http-param-schema.js
+++ b/sdk/http-param-schema.js
@@ -5,6 +5,12 @@ const m      = require('./mappings');
 
 class HttpParamSchema extends Schema {
 
+  /**
+   *
+   * @param {boolean} accessible
+   * @param {string} input
+   * @param {string} param
+   */
   constructor(accessible, input = 'query', param) {
     super();
 
@@ -13,6 +19,12 @@ class HttpParamSchema extends Schema {
     this._param      = param;
   }
 
+  /**
+   *
+   * @param mapping
+   * @returns {HttpParamSchema}
+   * @private
+   */
   static fromMapping(mapping) {
     const accessible = this.readProperty(mapping, m.accessible, false);
     const input      = this.readProperty(mapping, m.input, 'query');
@@ -25,14 +37,26 @@ class HttpParamSchema extends Schema {
     );
   }
 
+  /**
+   *
+   * @returns {boolean}
+   */
   isAccesible() {
     return this._accessible;
   }
 
+  /**
+   *
+   * @returns {string}
+   */
   getInput() {
     return this._input;
   }
 
+  /**
+   *
+   * @returns {string}
+   */
   getParam() {
     return this._param;
   }

--- a/sdk/http-request.js
+++ b/sdk/http-request.js
@@ -198,10 +198,22 @@ class HttpRequest {
       this[_data].getIn(['headers', name], defaultValue);
   }
 
+  /**
+   *
+   */
+  getHeaderArray() {
+    throw new Error('Not implemented');
+  }
   getHeaders() {
     return this[_data].has('headers') ? this[_data].get('headers').toJS() : {};
   }
 
+  /**
+   *
+   */
+  getHeadersArray() {
+    throw new Error('Not implemented');
+  }
   hasBody() {
     return this[_data].has('body') && this[_data].get('body').length > 0;
   }

--- a/sdk/http-request.js
+++ b/sdk/http-request.js
@@ -7,35 +7,71 @@ const File = require('./file');
 
 const _data = Symbol('data');
 
+/**
+ *
+ */
 class HttpRequest {
+  /**
+   *
+   * @param {Object} data Initial request data
+   */
   constructor(data) {
     this[_data] = Immutable.fromJS(data);
   }
 
+  /**
+   *
+   * @param {string} method
+   * @return {boolean}
+   */
   isMethod(method) {
     return this[_data].get('method').toLowerCase() === method.toLowerCase();
   }
 
+  /**
+   *
+   * @return {string}
+   */
   getMethod() {
     return this[_data].get('method').toUpperCase();
   }
 
+  /**
+   *
+   * @return {string}
+   */
   getUrl() {
     return this[_data].get('url');
   }
 
+  /**
+   *
+   * @return {string}
+   */
   getUrlScheme() {
     return url.parse(this[_data].get('url')).protocol;
   }
 
+  /**
+   * @return {string}
+   */
   getUrlHost() {
     return url.parse(this[_data].get('url')).host;
   }
 
+  /**
+   *
+   * @return {string}
+   */
   getUrlPath() {
     return url.parse(this[_data].get('url')).pathname;
   }
 
+  /**
+   *
+   * @param {string} name
+   * @return {boolean}
+   */
   hasQueryParam(name) {
     if (_.isNil(name)) {
       throw new Error('Specify a param `name`');
@@ -46,6 +82,12 @@ class HttpRequest {
     return this[_data].hasIn(['query', name]);
   }
 
+  /**
+   *
+   * @param {string} name
+   * @param {string} defaultValue
+   * @return {string}
+   */
   getQueryParam(name, defaultValue = '') {
     if (_.isNil(name)) {
       throw new Error('Specify a param `name`');
@@ -57,6 +99,12 @@ class HttpRequest {
       this[_data].getIn(['query', name, 0]) : defaultValue;
   }
 
+  /**
+   *
+   * @param {string} name
+   * @param {string} defaultValue
+   * @return {string}
+   */
   getQueryParamArray(name, defaultValue) {
     if (_.isNil(name)) {
       throw new Error('Specify a param `name`');
@@ -80,7 +128,7 @@ class HttpRequest {
 
   /**
    *
-   * @return {Array}
+   * @return {string[]}
    */
   getQueryParams() {
     const queryParams = this.getQueryParamsArray();
@@ -95,6 +143,11 @@ class HttpRequest {
     return this[_data].getIn(['query']).toJS();
   }
 
+  /**
+   *
+   * @param {string} name
+   * @return {boolean}
+   */
   hasPostParam(name) {
     if (_.isNil(name)) {
       throw new Error('Specify a param `name`');
@@ -105,6 +158,12 @@ class HttpRequest {
     return this[_data].hasIn(['postData', name]);
   }
 
+  /**
+   *
+   * @param name
+   * @param defaultValue
+   * @return {*}
+   */
   getPostParam(name, defaultValue = '') {
     if (_.isNil(name)) {
       throw new Error('Specify a param `name`');
@@ -116,6 +175,12 @@ class HttpRequest {
       this[_data].getIn(['postData', name, 0]) : defaultValue;
   }
 
+  /**
+   *
+   * @param name
+   * @param defaultValue
+   * @return {any | *}
+   */
   getPostParamArray(name, defaultValue) {
     if (_.isNil(name)) {
       throw new Error('Specify a param `name`');
@@ -138,7 +203,7 @@ class HttpRequest {
   }
 
   /**
-   * @return {Object}
+   * @return {Object[]}
    */
   getPostParamsArray() {
     return this[_data].get('postData').toJS();
@@ -146,7 +211,7 @@ class HttpRequest {
 
   /**
    *
-   * @return {Array}
+   * @return {Object[]}
    */
   getPostParams() {
     const paramsMap = this.getPostParams();
@@ -171,10 +236,18 @@ class HttpRequest {
     return this[_data].get('version') === version;
   }
 
+  /**
+   * @return {string}
+   */
   getProtocolVersion() {
     return this[_data].get('version');
   }
 
+  /**
+   *
+   * @param {string} name
+   * @return {boolean}
+   */
   hasHeader(name) {
     if (_.isNil(name)) {
       throw new Error('Specify a header `name`');
@@ -185,6 +258,12 @@ class HttpRequest {
     return this[_data].hasIn(['headers', name]);
   }
 
+  /**
+   *
+   * @param {string} name
+   * @param {string} defaultValue
+   * @return {string}
+   */
   getHeader(name, defaultValue = '') {
     if (_.isNil(name)) {
       throw new Error('Specify a header `name`');
@@ -204,6 +283,11 @@ class HttpRequest {
   getHeaderArray() {
     throw new Error('Not implemented');
   }
+
+  /**
+   *
+   * @return {Object}
+   */
   getHeaders() {
     return this[_data].has('headers') ? this[_data].get('headers').toJS() : {};
   }
@@ -214,14 +298,28 @@ class HttpRequest {
   getHeadersArray() {
     throw new Error('Not implemented');
   }
+
+  /**
+   *
+   * @return {boolean}
+   */
   hasBody() {
     return this[_data].has('body') && this[_data].get('body').length > 0;
   }
 
+  /**
+   *
+   * @return {string}
+   */
   getBody() {
     return this[_data].get('body') || '';
   }
 
+  /**
+   *
+   * @param name
+   * @return {boolean}
+   */
   hasFile(name) {
     if (_.isNil(name)) {
       throw new Error('Specify a file `name`');
@@ -232,6 +330,11 @@ class HttpRequest {
     return this[_data].hasIn(['files', name]);
   }
 
+  /**
+   *
+   * @param name
+   * @return {File}
+   */
   getFile(name) {
     if (_.isNil(name)) {
       throw new Error('Specify a file `name`');
@@ -242,6 +345,10 @@ class HttpRequest {
     return this[_data].getIn(['files', name]) || new File(name, '');
   }
 
+  /**
+   *
+   * @return {File[]}
+   */
   getFiles() {
     return this[_data].get('files').toJS();
   }

--- a/sdk/http-response.js
+++ b/sdk/http-response.js
@@ -7,7 +7,14 @@ const _data = Symbol('data');
 const _statusCode = Symbol('statusCode');
 const _statusText = Symbol('statusText');
 
+/**
+ *
+ */
 class HttpResponse {
+  /**
+   *
+   * @param {Object} data
+   */
   constructor(data) {
     this[_data] = Immutable.fromJS(data);
     const parts = this[_data].get('status').split(' ');
@@ -16,6 +23,11 @@ class HttpResponse {
     this[_statusText] = parts.slice(1).join(' ');
   }
 
+  /**
+   *
+   * @param version
+   * @return {boolean}
+   */
   isProtocolVersion(version) {
     if (_.isNil(version)) {
       throw new Error('Specify a protocol `version`');
@@ -25,10 +37,18 @@ class HttpResponse {
     return this[_data].get('version') === version;
   }
 
+  /**
+   * @return {string}
+   */
   getProtocolVersion() {
     return this[_data].get('version');
   }
 
+  /**
+   *
+   * @param version
+   * @return {boolean}
+   */
   setProtocolVersion(version) {
     if (_.isNil(version)) {
       throw new Error('Specify a protocol `version`');
@@ -40,6 +60,11 @@ class HttpResponse {
     return true;
   }
 
+  /**
+   *
+   * @param status
+   * @return {boolean}
+   */
   isStatus(status) {
     if (_.isNil(status)) {
       throw new Error('Specify a `status`');
@@ -49,18 +74,35 @@ class HttpResponse {
     return this[_data].get('status') === status;
   }
 
+  /**
+   * @return string
+   */
   getStatus() {
     return this[_data].get('status');
   }
 
+  /**
+   *
+   * @return {number}
+   */
   getStatusCode() {
     return this[_statusCode];
   }
 
+  /**
+   *
+   * @return {string}
+   */
   getStatusText() {
     return this[_statusText];
   }
 
+  /**
+   *
+   * @param code
+   * @param text
+   * @return {HttpResponse}
+   */
   setStatus(code, text) {
     if (_.isNil(code)) {
       throw new Error('Specify a status `code`');
@@ -75,9 +117,15 @@ class HttpResponse {
     }
 
     this[_data] = this[_data].set('status', `${code} ${text}`);
-    return true;
+
+    return this;
   }
 
+  /**
+   *
+   * @param name
+   * @return {boolean}
+   */
   hasHeader(name) {
     if (_.isNil(name)) {
       throw new Error('Specify a header `name`');
@@ -88,6 +136,12 @@ class HttpResponse {
     return this[_data].hasIn(['headers', name]);
   }
 
+  /**
+   *
+   * @param {string} name
+   * @param {string} defaultValue
+   * @return {string}
+   */
   getHeader(name, defaultValue = '') {
     if (_.isNil(name)) {
       throw new Error('Specify a header `name`');
@@ -107,6 +161,11 @@ class HttpResponse {
   getHeaderArray() {
     throw new Error('Not implemented');
   }
+
+  /**
+   *
+   * @return {Object}
+   */
   getHeaders() {
     return this[_data].has('headers') ? this[_data].get('headers').toJS() : {};
   }
@@ -118,6 +177,12 @@ class HttpResponse {
     throw new Error('Not implemented');
   }
 
+  /**
+   *
+   * @param {string} name
+   * @param {string} value
+   * @return {HttpResponse}
+   */
   setHeader(name, value) {
     if (_.isNil(name)) {
       throw new Error('Specify a header `name`');
@@ -132,19 +197,35 @@ class HttpResponse {
     }
 
     this[_data] = this[_data].setIn(['headers', name], value);
-    return true;
+
+    return this;
   }
 
+  /**
+   *
+   * @return {boolean}
+   */
   hasBody() {
     return this[_data].has('body') && this[_data].get('body').length > 0;
   }
 
+  /**
+   *
+   * @return {string}
+   */
   getBody() {
     return this[_data].get('body') || '';
   }
 
+  /**
+   *
+   * @param content
+   * @return {HttpResponse}
+   */
   setBody(content) {
     this[_data] = this[_data].set('body', String(content));
+
+    return this;
   }
 }
 

--- a/sdk/http-response.js
+++ b/sdk/http-response.js
@@ -101,8 +101,21 @@ class HttpResponse {
       this[_data].getIn(['headers', name], defaultValue);
   }
 
+  /**
+   * @return {string[]}
+    */
+  getHeaderArray() {
+    throw new Error('Not implemented');
+  }
   getHeaders() {
     return this[_data].has('headers') ? this[_data].get('headers').toJS() : {};
+  }
+
+  /**
+   * @return {Object[]}
+   */
+  getHeadersArray() {
+    throw new Error('Not implemented');
   }
 
   setHeader(name, value) {

--- a/sdk/http-service-schema.js
+++ b/sdk/http-service-schema.js
@@ -24,7 +24,7 @@ class HttpServiceSchema extends Schema {
    *
    * @returns {boolean}
    */
-  isAccesible() {
+  isAccessible() {
     return this._accessible;
   }
 

--- a/sdk/mapper.js
+++ b/sdk/mapper.js
@@ -73,7 +73,7 @@ class Mapper {
       }
     };
     if (responseApi.hasReturn()) {
-      payload[m.command_reply][m.result][m.response_return] = responseApi.getReturnType();
+      payload[m.command_reply][m.result][m.response_return] = responseApi._getReturnType();
     }
     return payload;
   }
@@ -182,7 +182,7 @@ class Mapper {
 
   getTransportMessage(transport) {
     const transportMessage = {
-      [m.meta]: transport.getMeta()
+      [m.meta]: transport._getMeta()
     };
 
     if (transport.hasFiles()) {

--- a/sdk/mapper.test.js
+++ b/sdk/mapper.test.js
@@ -55,7 +55,7 @@ describe('mapper', () => {
       const mapper    = new Mapper();
       const transport = mapper.getTransport(mockRequestTransport[m.command][m.arguments]);
       expect(transport).to.be.an.instanceOf(Transport);
-      expect(transport.getMeta()[m.gateway][1]).to.equal('http://10.0.2.15:9999');
+      expect(transport._getMeta()[m.gateway][1]).to.equal('http://10.0.2.15:9999');
     });
 
   });
@@ -70,7 +70,7 @@ describe('mapper', () => {
       );
       const mock = sinon.mock(resp);
       mock.expects('hasReturn').once().returns(true);
-      mock.expects('getReturnType').once().returns(null);
+      mock.expects('_getReturnType').once().returns(null);
       let payload = mapper.getResponseMessage(resp);
       expect(payload[m.command_reply][m.result][m.response_return]);
     });

--- a/sdk/middleware.js
+++ b/sdk/middleware.js
@@ -17,6 +17,7 @@ class Middleware extends Component {
    *
    * @param {string} actionName
    * @param {Object} payload
+   * @private
    */
   _processCommand(actionName, payload) {
     logger.debug('Incoming command', JSON.stringify(payload));

--- a/sdk/param-schema.js
+++ b/sdk/param-schema.js
@@ -31,7 +31,7 @@ class ParamSchema extends Schema {
    * @param {number} maxItems
    * @param {number} minItems
    * @param {string} uniqueItems
-   * @param {array} enumList
+   * @param {string[]} enumList
    * @param {number} multipleOf
    * @param {HttpParamSchema} httpParamSchema
    *
@@ -250,6 +250,10 @@ class ParamSchema extends Schema {
     return this._uniqueItems;
   }
 
+  /**
+   *
+   * @returns {string[]}
+   */
   getEnum() {
     return this._enumList;
   }

--- a/sdk/request.js
+++ b/sdk/request.js
@@ -55,6 +55,22 @@ class Request extends Api {
    *
    * @returns {string}
    */
+  getId() {
+    throw new Error('Not implemented');
+  }
+
+  /**
+   *
+   * @returns {string}
+   */
+  getTimestamp() {
+    throw new Error('Not implemented');
+  }
+
+  /**
+   *
+   * @returns {string}
+   */
   getGatewayProtocol() {
     return this._protocol;
   }

--- a/sdk/response.js
+++ b/sdk/response.js
@@ -82,7 +82,7 @@ class Response extends Api {
    * @returns {Transport}
    */
   getTransport() {
-    return this._transport;
+    return Object.freeze(this._transport);
   }
 
   /**
@@ -93,7 +93,7 @@ class Response extends Api {
   }
 
   /**
-   * @return {boolean}
+   * @return {array|number|boolean|string}
    */
   getReturn() {
     return this._return;
@@ -101,8 +101,9 @@ class Response extends Api {
 
   /**
    * @return {array|number|boolean|string}
+   * @protected
    */
-  getReturnType() {
+  _getReturnType() {
     if (this.return) {
       return this.return;
     }

--- a/sdk/service-schema.js
+++ b/sdk/service-schema.js
@@ -88,7 +88,7 @@ class ServiceSchema extends Schema {
 
   /**
    *
-   * @returns {Array}
+   * @returns {Object[]}
    */
   getActions() {
     return Object.keys(this._actions);

--- a/sdk/service-schema.test.js
+++ b/sdk/service-schema.test.js
@@ -83,7 +83,7 @@ describe('ServiceSchema', () => {
       const schema = ServiceSchema.fromMapping(name, version, mockServiceMapping);
       expect(schema).to.be.an.instanceOf(ServiceSchema);
 
-      expect(schema.getHttpSchema().isAccesible()).to.equal(true);
+      expect(schema.getHttpSchema().isAccessible()).to.equal(true);
       expect(schema.getHttpSchema().getBasePath()).to.equal('/1.0');
     });
 
@@ -182,7 +182,7 @@ describe('ServiceSchema', () => {
       const httpSchema  = new HttpServiceSchema(true, '/');
       let serviceSchema = new ServiceSchema(null, null, null, httpSchema);
       expect(serviceSchema.getHttpSchema()).to.equal(httpSchema);
-      expect(serviceSchema.getHttpSchema().isAccesible()).to.equal(true);
+      expect(serviceSchema.getHttpSchema().isAccessible()).to.equal(true);
       expect(serviceSchema.getHttpSchema().getBasePath()).to.equal('/');
     });
 

--- a/sdk/service.js
+++ b/sdk/service.js
@@ -13,6 +13,11 @@ class Service extends Component {
     super(options);
   }
 
+  /**
+   * Register a new action callback
+   * @param {string} name
+   * @param {function} callback
+   */
   action(name, callback) {
     this._setCallback(name, callback);
   }
@@ -42,6 +47,7 @@ class Service extends Component {
 
   /**
    * @param {Action} action The action request
+   * @private
    */
   runAction(action) {
     const actionName = action.getActionName();

--- a/sdk/service.test.js
+++ b/sdk/service.test.js
@@ -45,7 +45,7 @@ describe('Service', function () {
       return;
     }
 
-    throw Error('Calling an unknown action did not trigger an error');
+    throw new Error('Calling an unknown action did not trigger an error');
   });
 
   it('should run defined actions', (done) => {

--- a/sdk/transport.js
+++ b/sdk/transport.js
@@ -26,6 +26,10 @@ const _data = Symbol('data');
  * Transport class
  */
 class Transport {
+  /**
+   *
+   * @param {Object} data
+   */
   constructor(data = defaultData) {
     this[_data] = Immutable.fromJS(data);
 
@@ -34,31 +38,63 @@ class Transport {
     }
   }
 
-  getAsObject() {
+  /**
+   *
+   * @return {Object}
+   * @protected
+   */
+  _getAsObject() {
     return this[_data].toJS();
   }
 
-  getMeta() {
+  /**
+   *
+   * @return {Object}
+   * @protected
+   */
+  _getMeta() {
     return this[_data].get(m.meta).toJS();
   }
 
+  /**
+   *
+   * @return {string}
+   */
   getRequestId() {
     return this[_data].getIn([m.meta, m.id]);
   }
 
+  /**
+   *
+   * @return {string}
+   */
   getRequestTimestamp() {
     return this[_data].getIn([m.meta, m.datetime]);
   }
 
+  /**
+   *
+   * @return {string[]}
+   */
   getOriginService() {
     return this[_data].hasIn([m.meta, m.origin]) ?
       this[_data].getIn([m.meta, m.origin]).toJS() : [];
   }
 
+  /**
+   *
+   * @return {number}
+   */
   getOriginDuration() {
     return  this[_data].getIn([m.meta, m.duration]).toJS();
   }
 
+  /**
+   *
+   * @param {string} name
+   * @param {string} defaultValue
+   * @return {string}
+   */
   getProperty(name, defaultValue = '') {
     if (_.isNil(name)) {
       throw new Error('Specify a property `name`');
@@ -69,14 +105,25 @@ class Transport {
     return this[_data].getIn(['meta', 'properties', name]) || defaultValue;
   }
 
+  /**
+   *
+   * @return {Object}
+   */
   getProperties() {
     return this[_data].getIn(['meta', 'properties']).toJS() || {};
   }
 
+  /**
+   * @return true
+   */
   hasDownload() {
     return this[_data].has(m.body);
   }
 
+  /**
+   *
+   * @return {File}
+   */
   getDownload() {
     if (!this.hasDownload()) {
       return null;
@@ -87,18 +134,35 @@ class Transport {
     return new File(m.body, path, mime, filename, size, token);
   }
 
+  /**
+   * @return {boolean}
+   */
   hasFiles() {
     return this[_data].has(m.files);
   }
 
+  /**
+   *
+   * @return {*}
+   */
   getFiles() {
     return this.hasFiles() ? this[_data].get(m.files).toJS() : null;
   }
 
+  /**
+   *
+   */
   hasData() {
     return this[_data].has(m.data);
   }
 
+  /**
+   *
+   * @param {string} service
+   * @param {string} version
+   * @param {string} action
+   * @return {Object}
+   */
   getData(service, version, action) {
     let d = this[_data].get(m.data);
 
@@ -118,10 +182,18 @@ class Transport {
     return d.toJS();
   }
 
+  /**
+   *
+   */
   hasRelations() {
     return this[_data].has('relations');
   }
 
+  /**
+   *
+   * @param {string} service
+   * @return {Object}
+   */
   getRelations(service) {
     let relations = this[_data].get('relations') || Immutable.Map({});
 
@@ -132,10 +204,18 @@ class Transport {
     return relations.toJS();
   }
 
+  /**
+   * @return {boolean}
+   */
   hasLinks() {
     return this[_data].has('links');
   }
 
+  /**
+   *
+   * @param {string} service
+   * @return {Object}
+   */
   getLinks(service) {
     let links = this[_data].get('links') || Immutable.Map({});
 
@@ -146,10 +226,18 @@ class Transport {
     return links.toJS();
   }
 
+  /**
+   * @return {boolean}
+   */
   hasCalls() {
     return this[_data].has('calls');
   }
 
+  /**
+   *
+   * @param {string} service
+   * @return {Object}
+   */
   getCalls(service) {
     let calls = this[_data].get('calls') || Immutable.Map({});
 
@@ -160,10 +248,18 @@ class Transport {
     return calls.toJS();
   }
 
+  /**
+   * @return {boolean}
+   */
   hasTransactions() {
     return this[_data].has('transactions');
   }
 
+  /**
+   *
+   * @param {string} service
+   * @return {Object}
+   */
   getTransactions(service) {
     let transactions = this[_data].get('transactions') || Immutable.Map({});
 
@@ -174,6 +270,11 @@ class Transport {
     return transactions.toJS();
   }
 
+  /**
+   *
+   * @param {string} service
+   * @return {Object}
+   */
   getErrors(service) {
     let errors = this[_data].get('errors') || Immutable.Map({});
 
@@ -184,15 +285,37 @@ class Transport {
     return errors.toJS();
   }
 
+  /**
+   *
+   * @param name
+   * @param value
+   * @private
+   */
   _setProperty(name, value) {
     this[_data] = this[_data].setIn(['meta', 'properties', name], value);
   }
 
+  /**
+   *
+   * @param service
+   * @param version
+   * @param action
+   * @param name
+   * @return {boolean}
+   */
   hasFile(service, version, action, name) {
     return this[_data]
       .hasIn([m.files, this._getGatewayPublicAddress(), service, version, action, name]);
   }
 
+  /**
+   *
+   * @param service
+   * @param version
+   * @param action
+   * @param name
+   * @return {File}
+   */
   getFile(service, version, action, name) {
     let getGatewayPublicAddress = this._getGatewayPublicAddress();
 
@@ -201,18 +324,37 @@ class Transport {
       .toJS();
   }
 
+  /**
+   *
+   */
   hasBody() {
     return this[_data].has(m.body);
   }
 
+  /**
+   *
+   */
   getBody() {
     return this[_data].get(m.body);
   }
 
+  /**
+   *
+   * @param file
+   * @private
+   */
   _setBody(file) {
     this[_data] = this[_data].setIn([m.body], file);
   }
 
+  /**
+   *
+   * @param service
+   * @param version
+   * @param action
+   * @param source
+   * @private
+   */
   _setData(service, version, action, source) {
 
     const gatewayPublicAddress = this._getGatewayPublicAddress();
@@ -221,10 +363,22 @@ class Transport {
     this[_data] = this[_data].setIn(path, Immutable.fromJS(source));
   }
 
+  /**
+   *
+   * @return {Object}
+   * @private
+   */
   _getGatewayPublicAddress() {
-    return this.getMeta()[m.gateway][1];
+    return this._getMeta()[m.gateway][1];
   }
 
+  /**
+   *
+   * @param name
+   * @param primaryKey
+   * @param service
+   * @param foreignKey
+   */
   relateOne(name, primaryKey, service, foreignKey) {
     this[_data] = this[_data].setIn(
       ['relations', this._getGatewayPublicAddress(), name, primaryKey, service],
@@ -232,6 +386,13 @@ class Transport {
     );
   }
 
+  /**
+   *
+   * @param name
+   * @param primaryKey
+   * @param service
+   * @param foreignKeys
+   */
   relateMany(name, primaryKey, service, foreignKeys) {
     this[_data] = this[_data].setIn(
       ['relations', this._getGatewayPublicAddress(), name, primaryKey, service],
@@ -239,7 +400,14 @@ class Transport {
     );
   }
 
-
+  /**
+   *
+   * @param name
+   * @param primaryKey
+   * @param address
+   * @param service
+   * @param foreignKey
+   */
   relateOneRemote(name, primaryKey, address, service, foreignKey) {
     this[_data] = this[_data].setIn(
       ['relations', this._getGatewayPublicAddress(), name, primaryKey, address, service],
@@ -247,6 +415,14 @@ class Transport {
     );
   }
 
+  /**
+   *
+   * @param name
+   * @param primaryKey
+   * @param address
+   * @param service
+   * @param foreignKeys
+   */
   relateManyRemote(name, primaryKey, address, service, foreignKeys) {
     this[_data] = this[_data].setIn(
       ['relations', this._getGatewayPublicAddress(), name, primaryKey, address, service],
@@ -254,10 +430,24 @@ class Transport {
     );
   }
 
+  /**
+   *
+   * @param name
+   * @param link
+   * @param uri
+   * @private
+   */
   _setLink(name, link, uri) {
     this[_data] = this[_data].setIn(['links', name, link], uri);
   }
 
+  /**
+   *
+   * @param type
+   * @param name
+   * @param version
+   * @param transaction
+   */
   registerTransaction(type, name, version, transaction) {
     let data;
     if (this[_data].hasIn(['transactions', type, name, version])) {
@@ -272,6 +462,13 @@ class Transport {
     // this[_data] = this[_data].mergeIn(['transactions', type, name, version], Immutable.fromJS([transaction]));
   }
 
+  /**
+   *
+   * @param service
+   * @param version
+   * @param action
+   * @param file
+   */
   addFile(service, version, action, file) {
     this[_data] = this[_data].setIn([m.files, service, version, action], Immutable.fromJS(file));
   }

--- a/sdk/zmq-runtime-caller.js
+++ b/sdk/zmq-runtime-caller.js
@@ -40,7 +40,7 @@ class ZMQRuntimeCaller {
             version,
             targetAction
           ],
-          [m.transport]: action.getTransport().getAsObject(),
+          [m.transport]: action.getTransport()._getAsObject(),
           [m.params]: params,
           [m.files]: files,
         },


### PR DESCRIPTION
I've left one task open on https://github.com/orestes/katana-sdk-node/commit/879637e0748f943775783dfef061373a8d6125f5

@rvegas could you implement those? I think there were not in the spec at the time of the implementation. Specially the methods in `Request`, I'm almost sure those are coming from the _Request Attributes_ feature