### PR TITLE
Add getHeader Arrays, getId, and default getData

### DIFF
--- a/sdk/component.js
+++ b/sdk/component.js
@@ -293,7 +293,11 @@ class Component {
       this._mapper.getServiceCall(payload[m.command][m.arguments][m.call]),
       payload[m.command][m.arguments][m.meta][m.protocol],
       payload[m.command][m.arguments][m.meta][m.gateway],
-      payload[m.command][m.arguments][m.meta][m.client]
+      payload[m.command][m.arguments][m.meta][m.client],
+      null,
+      payload[m.command][m.arguments][m.meta][m.attributes],
+      payload[m.command][m.arguments][m.meta][m.id],
+      payload[m.command][m.arguments][m.meta][m.datetime]
     );
   }
 

--- a/sdk/http-request.js
+++ b/sdk/http-request.js
@@ -280,8 +280,17 @@ class HttpRequest {
   /**
    *
    */
-  getHeaderArray() {
-    throw new Error('Not implemented');
+  getHeaderArray(name, defaultValue = []) {
+    if (_.isNil(name)) {
+      throw new Error('Specify a header `name`');
+    } else if (!_.isString(name)) {
+      throw new TypeError('The header `name` must be a string');
+    }
+
+    return this[_data].getIn(['headers', name]) ?
+      this[_data].getIn(['headers', name]).toJS()
+      :
+      defaultValue;
   }
 
   /**
@@ -289,14 +298,22 @@ class HttpRequest {
    * @return {Object}
    */
   getHeaders() {
-    return this[_data].has('headers') ? this[_data].get('headers').toJS() : {};
+    if (!this[_data].has('headers')) {
+      return {};
+    }
+    const headers = this[_data].get('headers').toJS();
+    let headersObject = {};
+    Object.keys(headers).map((key) => {
+      headersObject[key] = this[_data].getIn(['headers', key]).get(0);
+    });
+    return headersObject;
   }
 
   /**
    *
    */
   getHeadersArray() {
-    throw new Error('Not implemented');
+    return this[_data].has('headers') ? this[_data].get('headers').toJS() : [];
   }
 
   /**

--- a/sdk/http-request.test.js
+++ b/sdk/http-request.test.js
@@ -278,7 +278,7 @@ describe('HttpRequest', () => {
 
   describe('getHeader()', () => {
     it('should return the header with the specified `name`', () => {
-      const headers = {'Content-Type': 'test'};
+      const headers = {'Content-Type': ['test']};
       const _mockRequest = _.merge({headers}, mockRequest);
       const httpRequest = new HttpRequest(_mockRequest);
       assert.equal(httpRequest.getHeader('Content-Type'), 'test');
@@ -289,7 +289,6 @@ describe('HttpRequest', () => {
       const _mockRequest = _.merge({headers}, mockRequest);
       const httpRequest  = new HttpRequest(_mockRequest);
       const defaultValue = 'text/plain';
-
       assert.equal(httpRequest.getHeader('Content-Type', defaultValue), defaultValue);
     });
 
@@ -299,17 +298,61 @@ describe('HttpRequest', () => {
     });
   });
 
-  describe('getHeaders()', () => {
-    it('should return all headers', () => {
-      const headers = {'Content-Type': 'test'};
+  describe('getHeaderArray()', () => {
+    it('should return the header array with the specified `name`', () => {
+      const headers = {'Content-Type': ['test', 'tast']};
       const _mockRequest = _.merge({headers}, mockRequest);
       const httpRequest = new HttpRequest(_mockRequest);
-      assert.deepEqual(httpRequest.getHeaders(), headers);
+      assert.deepEqual(httpRequest.getHeaderArray('Content-Type'), ['test', 'tast']);
+    });
+
+    it('should return the default value when header is not present', () => {
+      const headers      = {};
+      const _mockRequest = _.merge({headers}, mockRequest);
+      const httpRequest  = new HttpRequest(_mockRequest);
+      const defaultValue = 'text/plain';
+      assert.deepEqual(httpRequest.getHeaderArray('Content-Type', defaultValue), defaultValue);
+    });
+
+    it('should return the empty array if no defaultValue is present', () => {
+      const headers      = {};
+      const _mockRequest = _.merge({headers}, mockRequest);
+      const httpRequest  = new HttpRequest(_mockRequest);
+
+      assert.deepEqual(httpRequest.getHeaderArray('Content-Type'), []);
+    });
+
+    it('should throw an error if no header `name` specified', () => {
+      const httpRequest = new HttpRequest(mockRequest);
+      assert.throws(httpRequest.getHeaderArray, /Specify a header `name`/);
+    });
+  });
+
+  describe('getHeaders()', () => {
+    it('should return all headers', () => {
+      const headers = {'Content-Type': ['test', 'tast']};
+      const _mockRequest = _.merge({headers}, mockRequest);
+      const httpRequest = new HttpRequest(_mockRequest);
+      assert.deepEqual(httpRequest.getHeaders(), {'Content-Type': 'test'});
     });
 
     it('should return an empty set of headers when none are set', () => {
       const httpRequest = new HttpRequest(mockRequest);
       assert.deepEqual(httpRequest.getHeaders(), {});
+    });
+  });
+
+  describe('getHeaderArray()', () => {
+    it('should return all headers as arrays', () => {
+      const headers = {'Content-Type': ['test', 'tast']};
+      const _mockRequest = _.merge({headers}, mockRequest);
+      const httpRequest = new HttpRequest(_mockRequest);
+      assert.deepEqual(httpRequest.getHeadersArray(), headers);
+    });
+
+    it('should return an empty set of headers when none are set', () => {
+      const httpRequest = new HttpRequest(mockRequest);
+      assert.deepEqual(httpRequest.getHeadersArray(), []);
     });
   });
 

--- a/sdk/request.js
+++ b/sdk/request.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* eslint max-params: ["error", 14] */
+/* eslint max-params: ["error", 16] */
 
 const _            = require('lodash');
 const Api          = require('./api');
@@ -35,11 +35,13 @@ class Request extends Api {
    * @param {string} clientAddress
    * @param {Object} params
    * @param {Object} attributes
+   * @param {string} id
+   * @param {string} timestamp
    */
   constructor(
     component, path, name, version, frameworkVersion, variables, debug,
     httpRequest, serviceCall,
-    protocol, gatewayAddress, clientAddress, params, attributes
+    protocol, gatewayAddress, clientAddress, params, attributes, id, timestamp
   ) {
     super(component, path, name, version, frameworkVersion, variables, debug);
 
@@ -51,6 +53,8 @@ class Request extends Api {
     this._client         = clientAddress;
     this._params         = params || {};
     this._attributes     = attributes || {};
+    this._id             = id;
+    this._timestamp      = timestamp;
   }
 
   /**
@@ -58,7 +62,7 @@ class Request extends Api {
    * @returns {string}
    */
   getId() {
-    throw new Error('Not implemented');
+    return this._id;
   }
 
   /**
@@ -66,7 +70,7 @@ class Request extends Api {
    * @returns {string}
    */
   getTimestamp() {
-    throw new Error('Not implemented');
+    return this._timestamp;
   }
 
   /**

--- a/sdk/request.test.js
+++ b/sdk/request.test.js
@@ -23,21 +23,30 @@ describe('Request', () => {
     expect(request).to.be.an.instanceOf(Request);
   });
 
-  xdescribe('getGatewayProtocol()', () => {
+  describe('getGatewayProtocol()', () => {
     it('returns the protocol implemented by the Gateway component ', () => {
-
+      let call = new ServiceCall(null, null, 'get');
+      const request = new Request(null, null, null, null, {}, '1.0.0', false, mockHttpRequest,
+        call, 'http', null, null, {params: {}});
+      expect(request.getGatewayProtocol()).to.equal('http');
     });
   });
 
-  xdescribe('getGatewayAddress()', () => {
+  describe('getGatewayAddress()', () => {
     it('returns the public address of the Gateway component ', () => {
-
+      let call = new ServiceCall(null, null, 'get');
+      const request = new Request(null, null, null, null, {}, '1.0.0', false, mockHttpRequest,
+        call, 'http', '127.0.0.1', null, {params: {}});
+      expect(request.getGatewayAddress()).to.equal('127.0.0.1');
     });
   });
 
-  xdescribe('getClientAddress()', () => {
+  describe('getClientAddress()', () => {
     it('returns the IP address and port of the client which sent the request', () => {
-
+      let call = new ServiceCall(null, null, 'get');
+      const request = new Request(null, null, null, null, {}, '1.0.0', false, mockHttpRequest,
+        call, 'http', null, '127.0.0.2', {params: {}});
+      expect(request.getClientAddress()).to.equal('127.0.0.2');
     });
   });
 
@@ -301,12 +310,13 @@ describe('Request', () => {
   });
 
 
-  xdescribe('getHttpRequest()', () => {
-
+  describe('getHttpRequest()', () => {
     it('returns the instance of the HttpRequest for this Request', () => {
-
+      let call = new ServiceCall(null, null, 'get');
+      const request = new Request(null, null, null, null, {}, '1.0.0', false, mockHttpRequest, {},
+        call, null, null, null, {params: {}});
+      expect(request.getHttpRequest()).to.be.an.instanceOf(HttpRequest);
     });
-
   });
 
   describe('setAttribute()', () => {
@@ -330,6 +340,26 @@ describe('Request', () => {
       const request = new Request(null, null, null, null, {}, false, mockHttpRequest, {}, call,
         null, null, null, {params: {}});
       expect(() => request.setAttribute('foo', null)).to.throw(/`value` must be a String/);
+    });
+
+  });
+
+  describe('getId()', () => {
+    it('should get the uuid-4 ID of the request', () => {
+      let call = new ServiceCall(null, null, 'get');
+      const request = new Request(null, null, null, null, {}, false, mockHttpRequest, {}, call,
+        null, null, null, {params: {}}, null, 'f1b27da9-240b-40e3-99dd-a567e4498ed7');
+      expect(request.getId()).to.equal('f1b27da9-240b-40e3-99dd-a567e4498ed7');
+    });
+
+  });
+
+  describe('getTimestamp()', () => {
+    it('should get the creation timestamp of the request', () => {
+      let call = new ServiceCall(null, null, 'get');
+      const request = new Request(null, null, null, null, {}, false, mockHttpRequest, {}, call,
+        null, null, null, {params: {}}, null, '', '2016-04-12T02:49:05.692');
+      expect(request.getTimestamp()).to.equal('2016-04-12T02:49:05.692');
     });
 
   });

--- a/sdk/transport.js
+++ b/sdk/transport.js
@@ -166,6 +166,10 @@ class Transport {
   getData(service, version, action) {
     let d = this[_data].get(m.data);
 
+    if (!d) {
+      return [];
+    }
+
     if (service) {
       const gatewayPublicAddress = this._getGatewayPublicAddress();
       d = d.getIn([gatewayPublicAddress, service]) || Immutable.Map({});

--- a/sdk/transport.test.js
+++ b/sdk/transport.test.js
@@ -120,6 +120,13 @@ describe('Transport', () => {
       const transport = new Transport(_mockTransport);
       assert.deepEqual(transport.getData('users', '1.0.0', 'get'), d[''].users['1.0.0'].get);
     });
+
+    it('should return empty array if no data', () => {
+      const d = {'': ''};
+      const _mockTransport = _.merge({[m.data]: d}, mockTransport);
+      const transport = new Transport(_mockTransport);
+      assert.deepEqual(transport.getData('users', '1.0.0', 'get'), []);
+    });
   });
 
   describe('getRelations()', () => {


### PR DESCRIPTION
This closes non-implemented new methods and adds an improvement on transport.get_data()

Also includes more coverage.