### PR TITLE
fix(action): Return a new empty param when asking for one that doesn't exist

### DIFF
--- a/sdk/action.js
+++ b/sdk/action.js
@@ -712,6 +712,11 @@ for action: "${this._actionName}"`
     if (param instanceof Param) {
       return param;
     }
+
+    if (!param) {
+      return new Param(name, '', 'string', false);
+    }
+
     return new Param(name, param[m.value], param[m.type], this.hasParam(name));
   }
 

--- a/sdk/action.test.js
+++ b/sdk/action.test.js
@@ -108,6 +108,20 @@ describe('Action', () => {
       expect(param.getValue()).to.equal('James');
     });
 
+    it('should get a new empty parameter when requesting a param that does not exist', () => {
+      const mockParams = {
+          name: {
+            [m.value]: 'James',
+            [m.type]: 'string'
+          }
+      };
+      const action = new Action(null, null, 'users', '1.0', null, {}, false, '', mockParams, {});
+      const param = action.getParam('age');
+      expect(param).to.be.an.instanceOf(Param);
+      expect(param.getValue()).to.equal('');
+      expect(param.exists()).to.equal(false);
+    });
+
     it('should throw an error if the param `name` is not specified', () => {
       const action = new Action(null, 'users', '1.0', null, {}, false, '', {params: {}}, {});
       expect(() => action.getParam(null)).to.throw(/Specify a param `name`/);


### PR DESCRIPTION
Closes #51 
